### PR TITLE
一个bug: 启动参与者时索引设置错误

### DIFF
--- a/Lab3TestScript/lab3_testing.sh
+++ b/Lab3TestScript/lab3_testing.sh
@@ -250,7 +250,7 @@ function run_kvstore2pcsystem_c_and_other_language_robustly
 				if [[ $retval -eq 0 ]]
 				then
 					echo "Run participant[$i] successfully"
-					participants_pid[$j]=$!
+					participants_pid[$i]=$!
 					break
 				else
 					echo "Run participant[$i]. Retry times: [$j]"
@@ -313,7 +313,7 @@ function run_kvstore2pcsystem_java_robustly
 				if [[ $retval -eq 0 ]]
 				then
 					echo "Run participant[$i] successfully"
-					participants_pid[$j]=$!
+					participants_pid[$i]=$!
 					break
 				else
 					echo "Run participant[$i]. Retry times: [$j]"
@@ -374,7 +374,7 @@ function run_kvstore2pcsystem_python_robustly
 				if [[ $retval -eq 0 ]]
 				then
 					echo "Run participant[$i] successfully"
-					participants_pid[$j]=$!
+					participants_pid[$i]=$!
 					break
 				else
 					echo "Run participant[$i]. Retry times: [$j]"


### PR DESCRIPTION
一个bug: 启动参与者时索引设置错误. 索引本来应该是i, 但是写成了j, 导致后面关闭参与者进程的时候关闭错误. 会导致测试结果错误和执行完脚本之后有进程还在运行. 